### PR TITLE
refactor: Rename extension from "prompt-vault-extension" to "promptit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # VS Code Extension Change Log
 
-All notable changes to the "prompt-vault-extension" extension will be documented in this file.
+All notable changes to the "promptitude" extension will be documented in this file.
+
+## [1.2.0] - 2025-09-22
+
+- Renamed extension to promptitude for better visibility on vscode extensions marketplace.
 
 ## [1.1.0] - 2025-09-01
 
@@ -51,16 +55,16 @@ All notable changes to the "prompt-vault-extension" extension will be documented
 
 ### Configuration Options
 
-- `promptVault.enabled` - Enable/disable automatic syncing
-- `promptVault.frequency` - Sync frequency (startup, hourly, daily, weekly, manual)
-- `promptVault.customPath` - Custom prompts directory path
-- `promptVault.repository` - Repository URL to sync from
-- `promptVault.branch` - Repository branch to sync
-- `promptVault.syncOnStartup` - Sync when VS Code starts
-- `promptVault.showNotifications` - Show sync status notifications
-- `promptVault.debug` - Enable debug logging
+- `promptitude.enabled` - Enable/disable automatic syncing
+- `promptitude.frequency` - Sync frequency (startup, hourly, daily, weekly, manual)
+- `promptitude.customPath` - Custom prompts directory path
+- `promptitude.repository` - Repository URL to sync from
+- `promptitude.branch` - Repository branch to sync
+- `promptitude.syncOnStartup` - Sync when VS Code starts
+- `promptitude.showNotifications` - Show sync status notifications
+- `promptitude.debug` - Enable debug logging
 
 ### Commands
 
-- `promptVault.syncNow` - Manually trigger sync
-- `promptVault.showStatus` - Show extension status and configuration
+- `promptitude.syncNow` - Manually trigger sync
+- `promptitude.showStatus` - Show extension status and configuration

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,14 +7,14 @@
 1. **Install the extension:**
 
    ```bash
-   code --install-extension prompt-vault-extension-1.0.0.vsix
+   code --install-extension promptitude-extension-1.0.0.vsix
    ```
 
 2. **Or install via VS Code UI:**
    - Open VS Code
    - Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS)
    - Type "Extensions: Install from VSIX"
-   - Select the `prompt-vault-extension.vsix` file
+   - Select the `promptitude-extension.vsix` file
 
 ### Option 2: Development Mode
 
@@ -32,29 +32,29 @@
 
 2. **Configure Extension (Optional):**
    - Go to Settings (`Ctrl+,`)
-   - Search for "Prompt Vault"
+   - Search for "Promptitude"
    - Add a git repository to sync prompts from.
    - Adjust settings as needed
 
 ### 2. Test Manual Sync
 
 1. **Open Command Palette** (`Ctrl+Shift+P`)
-2. **Type:** "Prompt Vault: Sync Now"
+2. **Type:** "Promptitude: Sync Now"
 3. **Check status bar** for sync progress indicators
 4. **Verify prompts directory** was created and populated
 
 ### 3. Test Status Display
 
 1. **Open Command Palette** (`Ctrl+Shift+P`)
-2. **Type:** "Prompt Vault: Show Status"
+2. **Type:** "Promptitude: Show Status"
 3. **Review configuration** and status information
 
 ### 4. Check Debug Logs
 
 1. **Enable debug mode:**
-   - Settings → Search "promptVault.debug" → Enable
+   - Settings → Search "promptitude.debug" → Enable
 2. **View logs:**
-   - View → Output → Select "Prompt Vault" channel
+   - View → Output → Select "Promptitude" channel
 
 ## Expected Behavior
 
@@ -103,10 +103,10 @@
 
 ```bash
 # Check if extension is loaded
-code --list-extensions | grep prompt-vault
+code --list-extensions | grep promptitude
 
 # View extension logs
-# Open VS Code → View → Output → Select "Prompt Vault"
+# Open VS Code → View → Output → Select "Promptitude"
 
 # Reset extension data
 # Close VS Code, delete prompts directory, restart VS Code
@@ -125,10 +125,10 @@ npm run watch
 npx @vscode/vsce package
 
 # Install locally
-code --install-extension prompt-vault-extension-<version>.vsix
+code --install-extension promptitude-extension-<version>.vsix
 
 # Uninstall
-code --uninstall-extension logient-nventive.prompt-vault-extension
+code --uninstall-extension logient-nventive.promptitude-extension
 ```
 
 ## Extension Structure Verification

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prompt Vault Extension
+# Promptitude IDE Extension
 
 > Automatically sync GitHub Copilot prompts from multiple Git repositories to your local VS Code environment.
 
@@ -28,7 +28,7 @@ The Prompts Sync Extension automatically synchronizes the latest GitHub Copilot 
 
 ### Installation
 
-1. Download the latest `prompt-vault-extension.vsix` file from the releases
+1. Download the latest `promptitude-extension.vsix` file from the releases
 2. Open VS Code
 3. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS) to open the command palette
 4. Type "Extensions: Install from VSIX" and select it
@@ -38,7 +38,7 @@ The Prompts Sync Extension automatically synchronizes the latest GitHub Copilot 
 ### First-Time Setup
 
 1. Open VS Code Settings (`Ctrl+,` or `Cmd+,`)
-2. Search for "Prompt Vault"
+2. Search for "Promptitude"
 3. Configure your preferences (optional - defaults work for most users)
 4. The extension will automatically perform an initial sync
 
@@ -48,16 +48,16 @@ The Prompts Sync Extension automatically synchronizes the latest GitHub Copilot 
 
 | Setting                         | Description                      | Default                                                              | Type    |
 | ------------------------------- | -------------------------------- | -------------------------------------------------------------------- | ------- |
-| `promptVault.enabled`           | Enable/disable automatic syncing | `true`                                                               | boolean |
-| `promptVault.frequency`         | Sync frequency                   | `"daily"`                                                            | string  |
-| `promptVault.customPath`        | Custom prompts directory path    | `""`                                                                 | string  |
-| `promptVault.repositories`      | List of repository URLs          | `["https://github.com/MounirAbdousNventive/prompts-logient-nventive"]` | array   |
-| `promptVault.branch`            | Repository branch to sync        | `"master"`                                                           | string  |
-| `promptVault.syncOnStartup`     | Sync when VS Code starts         | `true`                                                               | boolean |
-| `promptVault.showNotifications` | Show sync status notifications   | `true`                                                               | boolean |
-| `promptVault.syncChatmode`      | Sync chatmode prompts            | `true`                                                               | boolean |
-| `promptVault.syncInstructions`  | Sync instructions prompts        | `true`                                                               | boolean |
-| `promptVault.syncPrompt`        | Sync prompt files                | `true`                                                               | boolean |
+| `promptitude.enabled`           | Enable/disable automatic syncing | `true`                                                               | boolean |
+| `promptitude.frequency`         | Sync frequency                   | `"daily"`                                                            | string  |
+| `promptitude.customPath`        | Custom prompts directory path    | `""`                                                                 | string  |
+| `promptitude.repositories`      | List of repository URLs          | `[]`                                                                 | array   |
+| `promptitude.branch`            | Repository branch to sync        | `"main"`                                                             | string  |
+| `promptitude.syncOnStartup`     | Sync when VS Code starts         | `true`                                                               | boolean |
+| `promptitude.showNotifications` | Show sync status notifications   | `true`                                                               | boolean |
+| `promptitude.syncChatmode`      | Sync chatmode prompts            | `true`                                                               | boolean |
+| `promptitude.syncInstructions`  | Sync instructions prompts        | `false`                                                              | boolean |
+| `promptitude.syncPrompt`        | Sync prompt files                | `true`                                                               | boolean |
 
 ### Sync Frequency Options
 
@@ -75,7 +75,7 @@ The extension automatically detects the correct prompts directory for your opera
 - **Windows**: `%APPDATA%\Code\User\prompts`
 - **Linux**: `~/.config/Code/User/prompts`
 
-You can override this by setting a custom path in `promptVault.customPath`.
+You can override this by setting a custom path in `promptitude.customPath`.
 
 ### Multiple Repository Configuration
 
@@ -85,13 +85,13 @@ The extension supports syncing from multiple Git repositories simultaneously. Th
 
 1. **Using VS Code Settings UI**:
    - Open Settings (`Ctrl+,` or `Cmd+,`)
-   - Search for "promptVault.repositories"
+   - Search for "promptitude.repositories"
    - Click "Add Item" to add each repository URL
 
 2. **Using JSON Configuration**:
    ```json
    {
-     "promptVault.repositories": [
+     "promptitude.repositories": [
        "https://github.com/your-org/prompts-main",
        "https://github.com/your-org/prompts-experimental",
        "https://github.com/another-org/shared-prompts"
@@ -188,7 +188,7 @@ All files are placed directly in the `User/prompts/` directory, removing any sub
 Enable debug logging:
 
 1. Open VS Code Settings
-2. Search for "promptVault.debug"
+2. Search for "promptitude.debug"
 3. Enable debug mode
 4. Check the "Prompts Sync" output channel for detailed logs
 
@@ -206,8 +206,7 @@ Enable debug logging:
 
 ```bash
 # Clone the repository
-git clone https://github.com/MounirAbdousNventive/prompts-logient-nventive.git
-cd prompts-logient-nventive/tools/vscode-extension
+git clone <url>
 
 # Install dependencies
 npm install
@@ -272,7 +271,7 @@ We welcome contributions to improve the extension! Please see our [Contribution 
 ### Version 1.2.0 (Multiple Repository Support)
 
 - ✅ **New Feature**: Support for syncing from multiple Git repositories
-- ✅ Added `promptVault.repositories` array setting for multiple repository URLs
+- ✅ Added `promptitude.repositories` array setting for multiple repository URLs
 - ✅ Enhanced error handling for repository conflicts and failures
 - ✅ Improved status display showing multi-repository sync results
 - ✅ Graceful handling of partial sync success scenarios
@@ -282,9 +281,9 @@ We welcome contributions to improve the extension! Please see our [Contribution 
 ### Version 1.1.0 (Selective Sync & Flattened Structure)
 
 - ✅ **New Feature**: Selective sync settings for different prompt types
-- ✅ Added `promptVault.syncChatmode` setting (default: true)
-- ✅ Added `promptVault.syncInstructions` setting (default: true)
-- ✅ Added `promptVault.syncPrompt` setting (default: true)
+- ✅ Added `promptitude.syncChatmode` setting (default: true)
+- ✅ Added `promptitude.syncInstructions` setting (default: true)
+- ✅ Added `promptitude.syncPrompt` setting (default: true)
 - ✅ Flattened folder structure - all files sync directly to `User/prompts/`
 - ✅ Enhanced status display showing selected sync types
 - ✅ Improved configurability and user control
@@ -301,7 +300,7 @@ We welcome contributions to improve the extension! Please see our [Contribution 
 
 ## 📄 License
 
-Internal use only - Logient/Nventive Development Team
+Apache 2.0
 
 ## 📞 Support
 
@@ -313,4 +312,4 @@ For support and questions:
 
 ---
 
-**Made with ❤️ by the Logient-Nventive DevOps Team**
+**Made with ❤️ by the Logient-nventive Team**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "prompts-sync-extension",
-  "version": "1.1.0",
+  "name": "promptitude-extension",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "prompts-sync-extension",
-      "version": "1.1.0",
+      "name": "promptitude-extension",
+      "version": "1.2.0",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.70.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "prompt-vault-extension",
-  "displayName": "Prompt Vault extension",
+  "name": "promptitude-extension",
+  "displayName": "Promptitude",
   "description": "Sync GitHub Copilot prompts, chatmodes and instructions from git repositories",
   "version": "1.2.0",
   "publisher": "logientnventive",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nventive/PromptVault.git",
+    "url": "https://github.com/nventive/promptitude.git",
     "directory": "tools/vscode-extension"
   },
   "engines": {
@@ -21,14 +21,14 @@
   "main": "./out/extension.js",
   "contributes": {
     "configuration": {
-      "title": "Prompt Vault",
+      "title": "Promptitude",
       "properties": {
-        "promptVault.enabled": {
+        "promptitude.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enable automatic synchronization"
         },
-        "promptVault.frequency": {
+        "promptitude.frequency": {
           "type": "string",
           "enum": [
             "startup",
@@ -40,12 +40,12 @@
           "default": "daily",
           "description": "Frequency of automatic sync"
         },
-        "promptVault.customPath": {
+        "promptitude.customPath": {
           "type": "string",
           "default": "",
           "description": "Custom prompts directory path (leave empty for default)"
         },
-        "promptVault.repositories": {
+        "promptitude.repositories": {
           "type": "array",
           "items": {
             "type": "string"
@@ -54,40 +54,40 @@
           "description": "List of repository URLs to sync from",
           "order": 0
         },
-        "promptVault.branch": {
+        "promptitude.branch": {
           "type": "string",
           "default": "main",
           "description": "Repository branch to sync",
           "order": 10
         },
-        "promptVault.syncOnStartup": {
+        "promptitude.syncOnStartup": {
           "type": "boolean",
           "default": true,
           "description": "Sync when Visual Studio Code starts"
         },
-        "promptVault.showNotifications": {
+        "promptitude.showNotifications": {
           "type": "boolean",
           "default": true,
           "description": "Show sync status notifications"
         },
-        "promptVault.debug": {
+        "promptitude.debug": {
           "type": "boolean",
           "default": false,
           "description": "Enable debug logging"
         },
-        "promptVault.syncChatmode": {
+        "promptitude.syncChatmode": {
           "type": "boolean",
           "default": true,
           "description": "Sync chatmodes",
           "order": 2
         },
-        "promptVault.syncInstructions": {
+        "promptitude.syncInstructions": {
           "type": "boolean",
           "default": false,
           "description": "Sync instructions",
           "order": 3
         },
-        "promptVault.syncPrompt": {
+        "promptitude.syncPrompt": {
           "type": "boolean",
           "default": true,
           "description": "Sync prompts",
@@ -97,14 +97,14 @@
     },
     "commands": [
       {
-        "command": "promptVault.syncNow",
+        "command": "promptitude.syncNow",
         "title": "Sync Now",
-        "category": "Prompt Vault"
+        "category": "Promptitude"
       },
       {
-        "command": "promptVault.showStatus",
+        "command": "promptitude.showStatus",
         "title": "Show Status",
-        "category": "Prompt Vault"
+        "category": "Promptitude"
       }
     ]
   },

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -18,19 +18,19 @@ export class ConfigManager {
     };
 
     get enabled(): boolean {
-        return vscode.workspace.getConfiguration('promptVault').get('enabled', true);
+        return vscode.workspace.getConfiguration('promptitude').get('enabled', true);
     }
 
     get frequency(): keyof SyncFrequency {
-        return vscode.workspace.getConfiguration('promptVault').get('frequency', 'daily');
+        return vscode.workspace.getConfiguration('promptitude').get('frequency', 'daily');
     }
 
     get customPath(): string {
-        return vscode.workspace.getConfiguration('promptVault').get('customPath', '');
+        return vscode.workspace.getConfiguration('promptitude').get('customPath', '');
     }
 
     get repositories(): string[] {
-        const repository = vscode.workspace.getConfiguration('promptVault').get<string[]>('repositories', []);
+        const repository = vscode.workspace.getConfiguration('promptitude').get<string[]>('repositories', []);
         const uniqueArray = Array.from(new Set(repository));
         if(uniqueArray.length != repository.length) {
             vscode.window.showWarningMessage('Duplicate repository URLs found in configuration. Duplicates have been removed.');
@@ -39,31 +39,31 @@ export class ConfigManager {
     }
 
     get branch(): string {
-        return vscode.workspace.getConfiguration('promptVault').get('branch', 'main');
+        return vscode.workspace.getConfiguration('promptitude').get('branch', 'main');
     }
 
     get syncOnStartup(): boolean {
-        return vscode.workspace.getConfiguration('promptVault').get('syncOnStartup', true);
+        return vscode.workspace.getConfiguration('promptitude').get('syncOnStartup', true);
     }
 
     get showNotifications(): boolean {
-        return vscode.workspace.getConfiguration('promptVault').get('showNotifications', true);
+        return vscode.workspace.getConfiguration('promptitude').get('showNotifications', true);
     }
 
     get debug(): boolean {
-        return vscode.workspace.getConfiguration('promptVault').get('debug', false);
+        return vscode.workspace.getConfiguration('promptitude').get('debug', false);
     }
 
     get syncChatmode(): boolean {
-        return vscode.workspace.getConfiguration('promptVault').get('syncChatmode', true);
+        return vscode.workspace.getConfiguration('promptitude').get('syncChatmode', true);
     }
 
     get syncInstructions(): boolean {
-        return vscode.workspace.getConfiguration('promptVault').get('syncInstructions', false);
+        return vscode.workspace.getConfiguration('promptitude').get('syncInstructions', false);
     }
 
     get syncPrompt(): boolean {
-        return vscode.workspace.getConfiguration('promptVault').get('syncPrompt', true);
+        return vscode.workspace.getConfiguration('promptitude').get('syncPrompt', true);
     }
 
     getSyncInterval(): number {
@@ -93,7 +93,7 @@ export class ConfigManager {
 
     onConfigurationChanged(callback: () => void): vscode.Disposable {
         return vscode.workspace.onDidChangeConfiguration(event => {
-            if (event.affectsConfiguration('promptVault')) {
+            if (event.affectsConfiguration('promptitude')) {
                 callback();
             }
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,11 +17,11 @@ export function activate(context: vscode.ExtensionContext) {
     syncManager = new SyncManager(configManager, statusBarManager, logger);
 
     // Register commands
-    const syncNowCommand = vscode.commands.registerCommand('promptVault.syncNow', async () => {
+    const syncNowCommand = vscode.commands.registerCommand('promptitude.syncNow', async () => {
         await syncManager.syncNow();
     });
 
-    const showStatusCommand = vscode.commands.registerCommand('promptVault.showStatus', async () => {
+    const showStatusCommand = vscode.commands.registerCommand('promptitude.showStatus', async () => {
         await syncManager.showStatus();
     });
 

--- a/src/statusBarManager.ts
+++ b/src/statusBarManager.ts
@@ -17,7 +17,7 @@ export class StatusBarManager implements vscode.Disposable {
             vscode.StatusBarAlignment.Right, 
             100
         );
-        this.statusBarItem.command = 'promptVault.syncNow';
+        this.statusBarItem.command = 'promptitude.syncNow';
         this.statusBarItem.show();
         this.updateStatusBar();
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -8,7 +8,7 @@ export class Logger {
     }
 
     private get isDebugEnabled(): boolean {
-        return vscode.workspace.getConfiguration('promptVault').get('debug', false);
+        return vscode.workspace.getConfiguration('promptitude').get('debug', false);
     }
 
     private log(level: string, message: string): void {

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -4,7 +4,7 @@ export class NotificationManager {
     private config: vscode.WorkspaceConfiguration;
 
     constructor() {
-        this.config = vscode.workspace.getConfiguration('promptVault');
+        this.config = vscode.workspace.getConfiguration('promptitude');
     }
 
     private get showNotifications(): boolean {
@@ -48,7 +48,7 @@ export class NotificationManager {
                 'No error details available';
             await this.showInfo(details);
         } else if (result === 'Retry Failed') {
-            vscode.commands.executeCommand('promptVault.syncNow');
+            vscode.commands.executeCommand('promptitude.syncNow');
         }
     }
 
@@ -60,7 +60,7 @@ export class NotificationManager {
         );
 
         if (result === 'Retry') {
-            vscode.commands.executeCommand('promptVault.syncNow');
+            vscode.commands.executeCommand('promptitude.syncNow');
         } else if (result === 'Show Logs') {
             vscode.commands.executeCommand('workbench.action.output.show');
         }


### PR DESCRIPTION
This pull request primarily renames the extension from "Prompt Vault" to "Promptitude" across all documentation, configuration, and code, to improve visibility and consistency. 

In addition to the renaming, it updates configuration keys, commands, and default settings to match the new extension name and branding.

**Repository and License Updates**

* Updated repository URLs and license in `package.json` and `README.md` to reflect the new name and open-source status (Apache 2.0). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R9) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24-R31) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L304-R303)

These changes ensure the extension is consistently branded as "Promptitude" and all configuration, usage, and documentation are aligned with the new name.