### PR TITLE
chore: Enhance CI/CD workflow with manual trigger inputs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,12 @@
 name: CI/CD Pipeline
 
 on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Why are you running this?
+        required: false
+        default: Manual trigger
   push:
     branches:
       - main
@@ -49,6 +55,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: vscode-extension
+          path: .
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -58,7 +65,7 @@ jobs:
       - name: Deploy to Marketplace
         run: |
           echo "Deploying to the marketplace..."
-          # Publish pre-built VSIX using the maintained @vscode/vsce package
+          # Publish pre-built VSIX using the @vscode/vsce package
           FILE=$(ls -1 *.vsix | head -n 1)
           echo "Publishing $FILE"
           if [ -z "${VSCE_PAT}" ]; then


### PR DESCRIPTION
This pull request updates the CI/CD workflow configuration to improve manual triggering and artifact handling. The main changes add a manual trigger option with a reason input, refine artifact download behavior, and clarify deployment comments.

Workflow improvements:

* Added a `workflow_dispatch` trigger to `.github/workflows/ci-cd.yml`, allowing manual runs with an optional `reason` input for context.

Artifact and deployment refinements:

* Updated the artifact download step to specify the current directory (`path: .`) when retrieving the `vscode-extension` artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added manual trigger capability to the CI/CD workflow with optional reason input for flexibility.
  * Optimized artifact download configuration in the deployment job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->