### PR TITLE
fix: Fix formatting of configuration table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ The Promptitude Extension automatically synchronizes the latest GitHub Copilot p
 | `promptitude.enabled`           | Enable/disable automatic syncing | `true`                                                               | boolean |
 | `promptitude.frequency`         | Sync frequency                   | `"daily"`                                                            | string  |
 | `promptitude.customPath`        | Custom prompts directory path    | `""`                                                                 | string  |
-| `promptitude.repositories`      | Repositories with optional branch (use `url` or `url|branch`) | `[]`                                                                 | array   |
+| `promptitude.repositories`      | Repositories with optional branch (use `url` or `url\|branch`) | `[]`                                   | array   |
 | `promptitude.syncOnStartup`     | Sync when VS Code starts         | `true`                                                               | boolean |
 | `promptitude.showNotifications` | Show sync status notifications   | `true`                                                               | boolean |
-| `promptitude.syncChatmode`      | Sync agent prompts (supports both agents/ and legacy chatmodes/ directories) | `true`                                                               | boolean |
+| `promptitude.syncChatmode`      | Sync agent prompts (supports both agents/ and legacy chatmodes/ directories) | `true`                   | boolean |
 | `promptitude.syncInstructions`  | Sync instructions prompts        | `true`                                                               | boolean |
 | `promptitude.syncPrompt`        | Sync prompt files                | `true`                                                               | boolean |
 


### PR DESCRIPTION
The `url|branch` part was breaking the table row. It's now fixed by escaping the `|`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed markdown table formatting in the README to ensure correct parsing and display of repository information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->