### PR TITLE
fix: improve source filter display with count badge and consistent layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "promptitude" extension will be documented in this file.
 
+## [1.5.7] - 2026-03-24
+
+### Fixed
+
+- Improved source filter dropdown to always display on its own full-width row, preventing layout shifts when toggling sources.
+- Added count badge (enabled/total) to the source dropdown button, matching the style of the other filter buttons.
+- Source dropdown label now shows "All Sources" when all selected and "Sources" when a subset is selected, for clearer context.
+
 ## [1.5.6] - 2026-03-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "promptitude-extension",
   "displayName": "Promptitude",
   "description": "Sync GitHub Copilot prompts, chatmodes and instructions from git repositories",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "publisher": "logientnventive",
   "icon": "resources/promptitude-icon.png",
   "repository": {

--- a/src/ui/promptCardsWebview.ts
+++ b/src/ui/promptCardsWebview.ts
@@ -283,8 +283,8 @@ export class PromptCardsWebviewProvider implements vscode.WebviewViewProvider {
 
         .source-filter-container {
             position: relative;
-            flex: 1;
-            min-width: fit-content;
+            flex-basis: 100%;
+            min-width: 0;
         }
 
         .source-dropdown-btn {
@@ -810,7 +810,8 @@ export class PromptCardsWebviewProvider implements vscode.WebviewViewProvider {
 
             const enabledCount = enabledSources.size === 0 ? sources.size + (localCount > 0 ? 1 : 0) : (hasNoneSentinel ? 0 : enabledSources.size);
             const totalSources = sources.size + (localCount > 0 ? 1 : 0);
-            const sourceFilterLabel = hasNoneSentinel ? 'None Selected' : (enabledSources.size === 0 ? 'All Sources' : \`\${enabledCount}/\${totalSources}\`);
+            const sourceFilterLabel = hasNoneSentinel ? 'No Sources Selected' : (enabledSources.size === 0 ? 'All Sources' : 'Sources');
+            const sourceCountLabel = \`\${enabledCount}/\${totalSources}\`;
 
             container.innerHTML = \`
                 <button class="filter-btn \${currentFilter === 'all' ? 'active' : ''}" onclick="setFilter('all')">
@@ -832,7 +833,7 @@ export class PromptCardsWebviewProvider implements vscode.WebviewViewProvider {
                 \${totalSources > 0 ? \`
                 <div class="source-filter-container">
                     <button class="source-dropdown-btn \${dropdownOpen ? 'open' : ''}" onclick="toggleDropdown(event)">
-                        <span>📦 \${sourceFilterLabel}</span>
+                        <span>📦 \${sourceFilterLabel} <span class="filter-count">\${sourceCountLabel}</span></span>
                         <span class="dropdown-arrow">▼</span>
                     </button>
                     <div class="source-dropdown-menu \${dropdownOpen ? 'open' : ''}">


### PR DESCRIPTION
## Summary

Improves the "All Sources" dropdown in the Prompts webview for better clarity and visual consistency.

## Changes

- **Full-width source filter row**: The source filter dropdown now always occupies its own line in the filter bar, regardless of label length. Previously, shorter labels (e.g., `7/8`) could cause it to share a line with other filter buttons.
- **Count badge**: Added an `enabled/total` count badge to the source dropdown button, matching the style of the other filter buttons (All, Agents, Prompts, Instructions).
- **Dynamic label**: The dropdown label now reads:
  - `📦 All Sources [n/n]` — when all sources are selected
  - `📦 Sources [x/n]` — when a subset is selected
  - `📦 None Selected [0/n]` — when no sources are selected

## Screenshots

Before:

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/767e879a-2720-4d53-b760-61ebaeb7b798" width="250"/></td>
    <td><img src="https://github.com/user-attachments/assets/ef418674-c885-492e-832d-4a1399989eee" width="250"/></td>
    <td><img src="https://github.com/user-attachments/assets/37c15164-3421-4db5-86ea-96bd36a36b0c" width="250"/></td>
  </tr>
</table>


After:
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/80545d3a-d0ae-4344-9400-873d98985034" width="250"/></td>
    <td><img src="https://github.com/user-attachments/assets/a23739fa-f31d-44e5-8bb5-c3e1008b1c14" width="250"/></td>
    <td><img src="https://github.com/user-attachments/assets/9fb27879-7ad3-4695-91f5-d9f1b8c2e9fa" width="250"/></td>
  </tr>
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Source filter now occupies its own full-width row; label shows “All Sources” or the static “Sources” text with a separate inline count badge indicating enabled/total.
* **Documentation**
  * Changelog updated to document the source filter layout and label/count behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->